### PR TITLE
Update Toggl api URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+# Unreleased
+
+There is a lot missing because the file had not been updated. I will start again from now
+
+## Changed
+
+- #2 Changed the flow from Esy to dune + opam.
+- #3 Updated API host from `api.toggl.com` to `api.track.toggl.com`.
+
 # 0.1.0 - 2020-01-01
 
 ## Added

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -2,7 +2,7 @@ open Types
 
 module F (Client : module type of Piaf.Client) = struct
   let create_client ?config () =
-    Client.create ?config @@ Uri.of_string "https://api.toggl.com"
+    Client.create ?config @@ Uri.of_string "https://api.track.toggl.com"
 
   module TimeEntry = struct
     open Lwt_result


### PR DESCRIPTION
Closes #3

Toggl had a rebranding and the URLs were updated at the same time. The
old URLs seemed to still work, but I wanted to do the update before
publishing to OPAM.