### PR TITLE
Fix/update tests

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,6 @@
   (atdgen-runtime (>= 2))
   (base64 (>= 3))
   (containers (>= 3.6))
-  (dune (>= 2.0))
   (piaf (>= 0.1.0))
   (ppx_deriving :build)
   (ptime (>= 1.0.0))

--- a/otoggl.opam
+++ b/otoggl.opam
@@ -9,12 +9,12 @@ license: "MIT"
 homepage: "https://github.com/unitrack-time-tracking/OToggl"
 bug-reports: "https://github.com/unitrack-time-tracking/OToggl/issues"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
   "atdgen" {build & >= "2"}
   "atdgen-runtime" {>= "2"}
   "base64" {>= "3"}
   "containers" {>= "3.6"}
-  "dune" {>= "2.9" & >= "2.0"}
   "piaf" {>= "0.1.0"}
   "ppx_deriving" {build}
   "ptime" {>= "1.0.0"}

--- a/test/test_toggl.ml
+++ b/test/test_toggl.ml
@@ -12,7 +12,7 @@ let get_datetime s =
 module TestNormalBehaviour = struct
   module Api = Api.F (TogglClient)
 
-  let client = Api.create_client ()
+  let client = Lwt_result.return TogglClient.client
 
   let time_entry_request =
     create_time_entry_request ~pid:123 ~wid:777 ~billable:false
@@ -140,7 +140,7 @@ module TestNotFound = struct
   module Api = Api.F (TogglClient)
   open Lwt_result
 
-  let client = Api.create_client ()
+  let client = Lwt_result.return TogglClient.client
 
   let test_stop_time_entry _switch () =
     client
@@ -175,7 +175,7 @@ module TestConnectionError = struct
   module Api = Api.F (TogglErrorClient)
   open Lwt_result
 
-  let client = Api.create_client ()
+  let client = Lwt_result.return TogglErrorClient.client
 
   let test_stop_time_entry _switch () =
     client

--- a/test/togglClient.ml
+++ b/test/togglClient.ml
@@ -1,6 +1,8 @@
 open Piaf
 include Client
 
+let client = Obj.magic None
+
 let time_entry =
   {json|
 {

--- a/test/togglClient.mli
+++ b/test/togglClient.mli
@@ -1,1 +1,3 @@
 include module type of Piaf.Client
+
+val client : t

--- a/test/togglErrorClient.ml
+++ b/test/togglErrorClient.ml
@@ -1,6 +1,8 @@
 open Piaf
 include Client
 
+let client = Obj.magic None
+
 let post
     (_t : t)
     ?(headers : (string * string) list option)

--- a/test/togglErrorClient.mli
+++ b/test/togglErrorClient.mli
@@ -1,1 +1,3 @@
 include module type of Piaf.Client
+
+val client : t


### PR DESCRIPTION
Without connection, the unit tests were not running despite mocking the endpoints because the `Piaf.Client.create` was trying to check the host, so we are now skipping the call to that function and pretend we have a readily instanciated client